### PR TITLE
Fix nuget.config

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <activePackageSource>
+  <packageSources>
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="PitStop public MyGet source" value="https://www.myget.org/F/pitstop/api/v3/index.json" />
-  </activePackageSource>
+  </packageSources>
 </configuration>


### PR DESCRIPTION
This PR fixes the nuget.config file so that it is being used correctly by the tools. Instead of using activePackageSources the feeds should be configured under the packageSources element. After changing this a dotnet restore from the command line works as expected.