### PR TITLE
Update nuget packages and rename servicename to Key

### DIFF
--- a/src/APIGateway/APIGateway.csproj
+++ b/src/APIGateway/APIGateway.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
-    <PackageReference Include="Ocelot" Version="8.0.1" />
+    <PackageReference Include="Ocelot" Version="12.0.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/APIGateway/OcelotConfig/Development/ocelot.CustomerManagementAPI.json
+++ b/src/APIGateway/OcelotConfig/Development/ocelot.CustomerManagementAPI.json
@@ -1,7 +1,7 @@
 ﻿{
   "ReRoutes": [
     {
-      "ServiceName": "CustomerManagementAPI",
+      "Key": "CustomerManagementAPI",
       "UpstreamPathTemplate": "/api/customers/",
       "DownstreamPathTemplate": "/api/customers",
       "DownstreamScheme": "http",
@@ -13,7 +13,7 @@
       ]
     },
     {
-      "ServiceName": "CustomerManagementAPI",
+      "Key": "CustomerManagementAPI",
       "UpstreamPathTemplate": "/api/customers/{trailingSegments}",
       "DownstreamPathTemplate": "/api/customers/{trailingSegments}",
       "DownstreamScheme": "http",

--- a/src/APIGateway/OcelotConfig/Development/ocelot.VehicleManagementAPI.json
+++ b/src/APIGateway/OcelotConfig/Development/ocelot.VehicleManagementAPI.json
@@ -1,7 +1,7 @@
 ﻿{
   "ReRoutes": [
     {
-      "ServiceName": "VehicleManagementAPI",
+      "Key": "VehicleManagementAPI",
       "UpstreamPathTemplate": "/api/vehicles/",
       "DownstreamPathTemplate": "/api/vehicles",
       "DownstreamScheme": "http",
@@ -13,7 +13,7 @@
       ]
     },
     {
-      "ServiceName": "VehicleManagementAPI",
+      "Key": "VehicleManagementAPI",
       "UpstreamPathTemplate": "/api/vehicles/{trailingSegments}",
       "DownstreamPathTemplate": "/api/vehicles/{trailingSegments}",
       "DownstreamScheme": "http",

--- a/src/APIGateway/OcelotConfig/Development/ocelot.WorkshopManagementAPI.json
+++ b/src/APIGateway/OcelotConfig/Development/ocelot.WorkshopManagementAPI.json
@@ -1,7 +1,7 @@
 ﻿{
   "ReRoutes": [
     {
-      "ServiceName": "WorkshopPlanningAPI",
+      "Key": "WorkshopPlanningAPI",
       "UpstreamPathTemplate": "/api/workshopplanning/{trailingSegments}",
       "DownstreamPathTemplate": "/api/workshopplanning/{trailingSegments}",
       "DownstreamScheme": "http",
@@ -13,7 +13,7 @@
       ]
     },
     {
-      "ServiceName": "WorkshopRefDataAPI",
+      "Key": "WorkshopRefDataAPI",
       "UpstreamPathTemplate": "/api/refdata/{trailingSegments}",
       "DownstreamPathTemplate": "/api/refdata/{trailingSegments}",
       "DownstreamScheme": "http",

--- a/src/APIGateway/OcelotConfig/Production/ocelot.CustomerManagementAPI.json
+++ b/src/APIGateway/OcelotConfig/Production/ocelot.CustomerManagementAPI.json
@@ -1,7 +1,7 @@
 ﻿{
   "ReRoutes": [
     {
-      "ServiceName": "CustomerManagementAPI",
+      "Key": "CustomerManagementAPI",
       "UpstreamPathTemplate": "/api/customers/",
       "DownstreamPathTemplate": "/api/customers",
       "DownstreamScheme": "http",
@@ -13,7 +13,7 @@
       ]
     },
     {
-      "ServiceName": "CustomerManagementAPI",
+      "Key": "CustomerManagementAPI",
       "UpstreamPathTemplate": "/api/customers/{trailingSegments}",
       "DownstreamPathTemplate": "/api/customers/{trailingSegments}",
       "DownstreamScheme": "http",

--- a/src/APIGateway/OcelotConfig/Production/ocelot.VehicleManagementAPI.json
+++ b/src/APIGateway/OcelotConfig/Production/ocelot.VehicleManagementAPI.json
@@ -1,7 +1,7 @@
 ﻿{
   "ReRoutes": [
     {
-      "ServiceName": "VehicleManagementAPI",
+      "Key": "VehicleManagementAPI",
       "UpstreamPathTemplate": "/api/vehicles/",
       "DownstreamPathTemplate": "/api/vehicles",
       "DownstreamScheme": "http",
@@ -13,7 +13,7 @@
       ]
     },
     {
-      "ServiceName": "VehicleManagementAPI",
+      "Key": "VehicleManagementAPI",
       "UpstreamPathTemplate": "/api/vehicles/{trailingSegments}",
       "DownstreamPathTemplate": "/api/vehicles/{trailingSegments}",
       "DownstreamScheme": "http",

--- a/src/APIGateway/OcelotConfig/Production/ocelot.WorkshopManagementAPI.json
+++ b/src/APIGateway/OcelotConfig/Production/ocelot.WorkshopManagementAPI.json
@@ -1,7 +1,7 @@
 ﻿{
   "ReRoutes": [
     {
-      "ServiceName": "WorkshopPlanningAPI",
+      "Key": "WorkshopPlanningAPI",
       "UpstreamPathTemplate": "/api/workshopplanning/{trailingSegments}",
       "DownstreamPathTemplate": "/api/workshopplanning/{trailingSegments}",
       "DownstreamScheme": "http",
@@ -20,7 +20,7 @@
       }
     },
     {
-      "ServiceName": "WorkshopRefDataAPI",
+      "Key": "WorkshopRefDataAPI",
       "UpstreamPathTemplate": "/api/refdata/{trailingSegments}",
       "DownstreamPathTemplate": "/api/refdata/{trailingSegments}",
       "DownstreamScheme": "http",

--- a/src/APIGateway/Program.cs
+++ b/src/APIGateway/Program.cs
@@ -33,7 +33,7 @@ namespace Pitstop.APIGateway
                     // add ocelot configuration
                     string ocelotConfigPath = Path.Combine(hostingContext.HostingEnvironment.ContentRootPath, "OcelotConfig");
                     ocelotConfigPath = Path.Combine(ocelotConfigPath, hostingContext.HostingEnvironment.EnvironmentName);
-                    config.AddOcelot(ocelotConfigPath);
+                    config.AddOcelot(ocelotConfigPath, hostingContext.HostingEnvironment);
 
                     config.AddEnvironmentVariables();
 

--- a/src/APIGateway/ocelot.json
+++ b/src/APIGateway/ocelot.json
@@ -1,1 +1,389 @@
-{"ReRoutes":[{"DownstreamPathTemplate":"/api/customers","UpstreamPathTemplate":"/api/customers/","UpstreamHttpMethod":[],"AddHeadersToRequest":{},"UpstreamHeaderTransform":{},"DownstreamHeaderTransform":{},"AddClaimsToRequest":{},"RouteClaimsRequirement":{},"AddQueriesToRequest":{},"RequestIdKey":null,"FileCacheOptions":{"TtlSeconds":0,"Region":null},"ReRouteIsCaseSensitive":false,"ServiceName":"CustomerManagementAPI","DownstreamScheme":"http","QoSOptions":{"ExceptionsAllowedBeforeBreaking":0,"DurationOfBreak":0,"TimeoutValue":0},"LoadBalancerOptions":{"Type":null,"Key":null,"Expiry":0},"RateLimitOptions":{"ClientWhitelist":[],"EnableRateLimiting":false,"Period":null,"PeriodTimespan":0.0,"Limit":0},"AuthenticationOptions":{"AuthenticationProviderKey":null,"AllowedScopes":[]},"HttpHandlerOptions":{"AllowAutoRedirect":false,"UseCookieContainer":false,"UseTracing":false,"UseProxy":true},"UseServiceDiscovery":false,"DownstreamHostAndPorts":[{"Host":"localhost","Port":5100}],"UpstreamHost":null,"Key":null,"DelegatingHandlers":[],"Priority":1,"Timeout":0,"DangerousAcceptAnyServerCertificateValidator":false},{"DownstreamPathTemplate":"/api/customers/{trailingSegments}","UpstreamPathTemplate":"/api/customers/{trailingSegments}","UpstreamHttpMethod":[],"AddHeadersToRequest":{},"UpstreamHeaderTransform":{},"DownstreamHeaderTransform":{},"AddClaimsToRequest":{},"RouteClaimsRequirement":{},"AddQueriesToRequest":{},"RequestIdKey":null,"FileCacheOptions":{"TtlSeconds":0,"Region":null},"ReRouteIsCaseSensitive":false,"ServiceName":"CustomerManagementAPI","DownstreamScheme":"http","QoSOptions":{"ExceptionsAllowedBeforeBreaking":0,"DurationOfBreak":0,"TimeoutValue":0},"LoadBalancerOptions":{"Type":null,"Key":null,"Expiry":0},"RateLimitOptions":{"ClientWhitelist":[],"EnableRateLimiting":false,"Period":null,"PeriodTimespan":0.0,"Limit":0},"AuthenticationOptions":{"AuthenticationProviderKey":null,"AllowedScopes":[]},"HttpHandlerOptions":{"AllowAutoRedirect":false,"UseCookieContainer":false,"UseTracing":false,"UseProxy":true},"UseServiceDiscovery":false,"DownstreamHostAndPorts":[{"Host":"localhost","Port":5100}],"UpstreamHost":null,"Key":null,"DelegatingHandlers":[],"Priority":1,"Timeout":0,"DangerousAcceptAnyServerCertificateValidator":false},{"DownstreamPathTemplate":"/api/vehicles","UpstreamPathTemplate":"/api/vehicles/","UpstreamHttpMethod":[],"AddHeadersToRequest":{},"UpstreamHeaderTransform":{},"DownstreamHeaderTransform":{},"AddClaimsToRequest":{},"RouteClaimsRequirement":{},"AddQueriesToRequest":{},"RequestIdKey":null,"FileCacheOptions":{"TtlSeconds":0,"Region":null},"ReRouteIsCaseSensitive":false,"ServiceName":"VehicleManagementAPI","DownstreamScheme":"http","QoSOptions":{"ExceptionsAllowedBeforeBreaking":0,"DurationOfBreak":0,"TimeoutValue":0},"LoadBalancerOptions":{"Type":null,"Key":null,"Expiry":0},"RateLimitOptions":{"ClientWhitelist":[],"EnableRateLimiting":false,"Period":null,"PeriodTimespan":0.0,"Limit":0},"AuthenticationOptions":{"AuthenticationProviderKey":null,"AllowedScopes":[]},"HttpHandlerOptions":{"AllowAutoRedirect":false,"UseCookieContainer":false,"UseTracing":false,"UseProxy":true},"UseServiceDiscovery":false,"DownstreamHostAndPorts":[{"Host":"localhost","Port":5000}],"UpstreamHost":null,"Key":null,"DelegatingHandlers":[],"Priority":1,"Timeout":0,"DangerousAcceptAnyServerCertificateValidator":false},{"DownstreamPathTemplate":"/api/vehicles/{trailingSegments}","UpstreamPathTemplate":"/api/vehicles/{trailingSegments}","UpstreamHttpMethod":[],"AddHeadersToRequest":{},"UpstreamHeaderTransform":{},"DownstreamHeaderTransform":{},"AddClaimsToRequest":{},"RouteClaimsRequirement":{},"AddQueriesToRequest":{},"RequestIdKey":null,"FileCacheOptions":{"TtlSeconds":0,"Region":null},"ReRouteIsCaseSensitive":false,"ServiceName":"VehicleManagementAPI","DownstreamScheme":"http","QoSOptions":{"ExceptionsAllowedBeforeBreaking":0,"DurationOfBreak":0,"TimeoutValue":0},"LoadBalancerOptions":{"Type":null,"Key":null,"Expiry":0},"RateLimitOptions":{"ClientWhitelist":[],"EnableRateLimiting":false,"Period":null,"PeriodTimespan":0.0,"Limit":0},"AuthenticationOptions":{"AuthenticationProviderKey":null,"AllowedScopes":[]},"HttpHandlerOptions":{"AllowAutoRedirect":false,"UseCookieContainer":false,"UseTracing":false,"UseProxy":true},"UseServiceDiscovery":false,"DownstreamHostAndPorts":[{"Host":"localhost","Port":5000}],"UpstreamHost":null,"Key":null,"DelegatingHandlers":[],"Priority":1,"Timeout":0,"DangerousAcceptAnyServerCertificateValidator":false},{"DownstreamPathTemplate":"/api/workshopplanning/{trailingSegments}","UpstreamPathTemplate":"/api/workshopplanning/{trailingSegments}","UpstreamHttpMethod":[],"AddHeadersToRequest":{},"UpstreamHeaderTransform":{},"DownstreamHeaderTransform":{},"AddClaimsToRequest":{},"RouteClaimsRequirement":{},"AddQueriesToRequest":{},"RequestIdKey":null,"FileCacheOptions":{"TtlSeconds":0,"Region":null},"ReRouteIsCaseSensitive":false,"ServiceName":"WorkshopPlanningAPI","DownstreamScheme":"http","QoSOptions":{"ExceptionsAllowedBeforeBreaking":0,"DurationOfBreak":0,"TimeoutValue":0},"LoadBalancerOptions":{"Type":null,"Key":null,"Expiry":0},"RateLimitOptions":{"ClientWhitelist":[],"EnableRateLimiting":false,"Period":null,"PeriodTimespan":0.0,"Limit":0},"AuthenticationOptions":{"AuthenticationProviderKey":null,"AllowedScopes":[]},"HttpHandlerOptions":{"AllowAutoRedirect":false,"UseCookieContainer":false,"UseTracing":false,"UseProxy":true},"UseServiceDiscovery":false,"DownstreamHostAndPorts":[{"Host":"localhost","Port":5200}],"UpstreamHost":null,"Key":null,"DelegatingHandlers":[],"Priority":1,"Timeout":0,"DangerousAcceptAnyServerCertificateValidator":false},{"DownstreamPathTemplate":"/api/refdata/{trailingSegments}","UpstreamPathTemplate":"/api/refdata/{trailingSegments}","UpstreamHttpMethod":[],"AddHeadersToRequest":{},"UpstreamHeaderTransform":{},"DownstreamHeaderTransform":{},"AddClaimsToRequest":{},"RouteClaimsRequirement":{},"AddQueriesToRequest":{},"RequestIdKey":null,"FileCacheOptions":{"TtlSeconds":0,"Region":null},"ReRouteIsCaseSensitive":false,"ServiceName":"WorkshopRefDataAPI","DownstreamScheme":"http","QoSOptions":{"ExceptionsAllowedBeforeBreaking":0,"DurationOfBreak":0,"TimeoutValue":0},"LoadBalancerOptions":{"Type":null,"Key":null,"Expiry":0},"RateLimitOptions":{"ClientWhitelist":[],"EnableRateLimiting":false,"Period":null,"PeriodTimespan":0.0,"Limit":0},"AuthenticationOptions":{"AuthenticationProviderKey":null,"AllowedScopes":[]},"HttpHandlerOptions":{"AllowAutoRedirect":false,"UseCookieContainer":false,"UseTracing":false,"UseProxy":true},"UseServiceDiscovery":false,"DownstreamHostAndPorts":[{"Host":"localhost","Port":5200}],"UpstreamHost":null,"Key":null,"DelegatingHandlers":[],"Priority":1,"Timeout":0,"DangerousAcceptAnyServerCertificateValidator":false}],"Aggregates":[],"GlobalConfiguration":{"RequestIdKey":null,"ServiceDiscoveryProvider":{"Host":null,"Port":0,"Type":null,"Token":null,"ConfigurationKey":null,"PollingInterval":0},"RateLimitOptions":{"ClientIdHeader":"ClientId","QuotaExceededMessage":null,"RateLimitCounterPrefix":"ocelot","DisableRateLimitHeaders":false,"HttpStatusCode":429},"QoSOptions":{"ExceptionsAllowedBeforeBreaking":0,"DurationOfBreak":0,"TimeoutValue":0},"BaseUrl":"http://localhost:10000","LoadBalancerOptions":{"Type":null,"Key":null,"Expiry":0},"DownstreamScheme":null,"HttpHandlerOptions":{"AllowAutoRedirect":false,"UseCookieContainer":false,"UseTracing":false,"UseProxy":true}}}
+{
+    "ReRoutes": [
+        {
+            "DownstreamPathTemplate": "/api/customers",
+            "UpstreamPathTemplate": "/api/customers/",
+            "UpstreamHttpMethod": [],
+            "AddHeadersToRequest": {},
+            "UpstreamHeaderTransform": {},
+            "DownstreamHeaderTransform": {},
+            "AddClaimsToRequest": {},
+            "RouteClaimsRequirement": {},
+            "AddQueriesToRequest": {},
+            "RequestIdKey": null,
+            "FileCacheOptions": {
+                "TtlSeconds": 0,
+                "Region": null
+            },
+            "ReRouteIsCaseSensitive": false,
+            "Key": "CustomerManagementAPI",
+            "DownstreamScheme": "http",
+            "QoSOptions": {
+                "ExceptionsAllowedBeforeBreaking": 0,
+                "DurationOfBreak": 0,
+                "TimeoutValue": 0
+            },
+            "LoadBalancerOptions": {
+                "Type": null,
+                "Key": null,
+                "Expiry": 0
+            },
+            "RateLimitOptions": {
+                "ClientWhitelist": [],
+                "EnableRateLimiting": false,
+                "Period": null,
+                "PeriodTimespan": 0.0,
+                "Limit": 0
+            },
+            "AuthenticationOptions": {
+                "AuthenticationProviderKey": null,
+                "AllowedScopes": []
+            },
+            "HttpHandlerOptions": {
+                "AllowAutoRedirect": false,
+                "UseCookieContainer": false,
+                "UseTracing": false,
+                "UseProxy": true
+            },
+            "UseServiceDiscovery": false,
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "localhost",
+                    "Port": 5100
+                }
+            ],
+            "UpstreamHost": null,
+            "DelegatingHandlers": [],
+            "Priority": 1,
+            "Timeout": 0,
+            "DangerousAcceptAnyServerCertificateValidator": false
+        },
+        {
+            "DownstreamPathTemplate": "/api/customers/{trailingSegments}",
+            "UpstreamPathTemplate": "/api/customers/{trailingSegments}",
+            "UpstreamHttpMethod": [],
+            "AddHeadersToRequest": {},
+            "UpstreamHeaderTransform": {},
+            "DownstreamHeaderTransform": {},
+            "AddClaimsToRequest": {},
+            "RouteClaimsRequirement": {},
+            "AddQueriesToRequest": {},
+            "RequestIdKey": null,
+            "FileCacheOptions": {
+                "TtlSeconds": 0,
+                "Region": null
+            },
+            "ReRouteIsCaseSensitive": false,
+            "Key": "CustomerManagementAPI",
+            "DownstreamScheme": "http",
+            "QoSOptions": {
+                "ExceptionsAllowedBeforeBreaking": 0,
+                "DurationOfBreak": 0,
+                "TimeoutValue": 0
+            },
+            "LoadBalancerOptions": {
+                "Type": null,
+                "Key": null,
+                "Expiry": 0
+            },
+            "RateLimitOptions": {
+                "ClientWhitelist": [],
+                "EnableRateLimiting": false,
+                "Period": null,
+                "PeriodTimespan": 0.0,
+                "Limit": 0
+            },
+            "AuthenticationOptions": {
+                "AuthenticationProviderKey": null,
+                "AllowedScopes": []
+            },
+            "HttpHandlerOptions": {
+                "AllowAutoRedirect": false,
+                "UseCookieContainer": false,
+                "UseTracing": false,
+                "UseProxy": true
+            },
+            "UseServiceDiscovery": false,
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "localhost",
+                    "Port": 5100
+                }
+            ],
+            "UpstreamHost": null,
+            "DelegatingHandlers": [],
+            "Priority": 1,
+            "Timeout": 0,
+            "DangerousAcceptAnyServerCertificateValidator": false
+        },
+        {
+            "DownstreamPathTemplate": "/api/vehicles",
+            "UpstreamPathTemplate": "/api/vehicles/",
+            "UpstreamHttpMethod": [],
+            "AddHeadersToRequest": {},
+            "UpstreamHeaderTransform": {},
+            "DownstreamHeaderTransform": {},
+            "AddClaimsToRequest": {},
+            "RouteClaimsRequirement": {},
+            "AddQueriesToRequest": {},
+            "RequestIdKey": null,
+            "FileCacheOptions": {
+                "TtlSeconds": 0,
+                "Region": null
+            },
+            "ReRouteIsCaseSensitive": false,
+            "Key": "VehicleManagementAPI",
+            "DownstreamScheme": "http",
+            "QoSOptions": {
+                "ExceptionsAllowedBeforeBreaking": 0,
+                "DurationOfBreak": 0,
+                "TimeoutValue": 0
+            },
+            "LoadBalancerOptions": {
+                "Type": null,
+                "Key": null,
+                "Expiry": 0
+            },
+            "RateLimitOptions": {
+                "ClientWhitelist": [],
+                "EnableRateLimiting": false,
+                "Period": null,
+                "PeriodTimespan": 0.0,
+                "Limit": 0
+            },
+            "AuthenticationOptions": {
+                "AuthenticationProviderKey": null,
+                "AllowedScopes": []
+            },
+            "HttpHandlerOptions": {
+                "AllowAutoRedirect": false,
+                "UseCookieContainer": false,
+                "UseTracing": false,
+                "UseProxy": true
+            },
+            "UseServiceDiscovery": false,
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "localhost",
+                    "Port": 5000
+                }
+            ],
+            "UpstreamHost": null,
+            "DelegatingHandlers": [],
+            "Priority": 1,
+            "Timeout": 0,
+            "DangerousAcceptAnyServerCertificateValidator": false
+        },
+        {
+            "DownstreamPathTemplate": "/api/vehicles/{trailingSegments}",
+            "UpstreamPathTemplate": "/api/vehicles/{trailingSegments}",
+            "UpstreamHttpMethod": [],
+            "AddHeadersToRequest": {},
+            "UpstreamHeaderTransform": {},
+            "DownstreamHeaderTransform": {},
+            "AddClaimsToRequest": {},
+            "RouteClaimsRequirement": {},
+            "AddQueriesToRequest": {},
+            "RequestIdKey": null,
+            "FileCacheOptions": {
+                "TtlSeconds": 0,
+                "Region": null
+            },
+            "ReRouteIsCaseSensitive": false,
+            "Key": "VehicleManagementAPI",
+            "DownstreamScheme": "http",
+            "QoSOptions": {
+                "ExceptionsAllowedBeforeBreaking": 0,
+                "DurationOfBreak": 0,
+                "TimeoutValue": 0
+            },
+            "LoadBalancerOptions": {
+                "Type": null,
+                "Key": null,
+                "Expiry": 0
+            },
+            "RateLimitOptions": {
+                "ClientWhitelist": [],
+                "EnableRateLimiting": false,
+                "Period": null,
+                "PeriodTimespan": 0.0,
+                "Limit": 0
+            },
+            "AuthenticationOptions": {
+                "AuthenticationProviderKey": null,
+                "AllowedScopes": []
+            },
+            "HttpHandlerOptions": {
+                "AllowAutoRedirect": false,
+                "UseCookieContainer": false,
+                "UseTracing": false,
+                "UseProxy": true
+            },
+            "UseServiceDiscovery": false,
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "localhost",
+                    "Port": 5000
+                }
+            ],
+            "UpstreamHost": null,
+            "DelegatingHandlers": [],
+            "Priority": 1,
+            "Timeout": 0,
+            "DangerousAcceptAnyServerCertificateValidator": false
+        },
+        {
+            "DownstreamPathTemplate": "/api/workshopplanning/{trailingSegments}",
+            "UpstreamPathTemplate": "/api/workshopplanning/{trailingSegments}",
+            "UpstreamHttpMethod": [],
+            "AddHeadersToRequest": {},
+            "UpstreamHeaderTransform": {},
+            "DownstreamHeaderTransform": {},
+            "AddClaimsToRequest": {},
+            "RouteClaimsRequirement": {},
+            "AddQueriesToRequest": {},
+            "RequestIdKey": null,
+            "FileCacheOptions": {
+                "TtlSeconds": 0,
+                "Region": null
+            },
+            "ReRouteIsCaseSensitive": false,
+            "Key": "WorkshopPlanningAPI",
+            "DownstreamScheme": "http",
+            "QoSOptions": {
+                "ExceptionsAllowedBeforeBreaking": 0,
+                "DurationOfBreak": 0,
+                "TimeoutValue": 0
+            },
+            "LoadBalancerOptions": {
+                "Type": null,
+                "Key": null,
+                "Expiry": 0
+            },
+            "RateLimitOptions": {
+                "ClientWhitelist": [],
+                "EnableRateLimiting": false,
+                "Period": null,
+                "PeriodTimespan": 0.0,
+                "Limit": 0
+            },
+            "AuthenticationOptions": {
+                "AuthenticationProviderKey": null,
+                "AllowedScopes": []
+            },
+            "HttpHandlerOptions": {
+                "AllowAutoRedirect": false,
+                "UseCookieContainer": false,
+                "UseTracing": false,
+                "UseProxy": true
+            },
+            "UseServiceDiscovery": false,
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "localhost",
+                    "Port": 5200
+                }
+            ],
+            "UpstreamHost": null,
+            "DelegatingHandlers": [],
+            "Priority": 1,
+            "Timeout": 0,
+            "DangerousAcceptAnyServerCertificateValidator": false
+        },
+        {
+            "DownstreamPathTemplate": "/api/refdata/{trailingSegments}",
+            "UpstreamPathTemplate": "/api/refdata/{trailingSegments}",
+            "UpstreamHttpMethod": [],
+            "AddHeadersToRequest": {},
+            "UpstreamHeaderTransform": {},
+            "DownstreamHeaderTransform": {},
+            "AddClaimsToRequest": {},
+            "RouteClaimsRequirement": {},
+            "AddQueriesToRequest": {},
+            "RequestIdKey": null,
+            "FileCacheOptions": {
+                "TtlSeconds": 0,
+                "Region": null
+            },
+            "ReRouteIsCaseSensitive": false,
+            "Key": "WorkshopRefDataAPI",
+            "DownstreamScheme": "http",
+            "QoSOptions": {
+                "ExceptionsAllowedBeforeBreaking": 0,
+                "DurationOfBreak": 0,
+                "TimeoutValue": 0
+            },
+            "LoadBalancerOptions": {
+                "Type": null,
+                "Key": null,
+                "Expiry": 0
+            },
+            "RateLimitOptions": {
+                "ClientWhitelist": [],
+                "EnableRateLimiting": false,
+                "Period": null,
+                "PeriodTimespan": 0.0,
+                "Limit": 0
+            },
+            "AuthenticationOptions": {
+                "AuthenticationProviderKey": null,
+                "AllowedScopes": []
+            },
+            "HttpHandlerOptions": {
+                "AllowAutoRedirect": false,
+                "UseCookieContainer": false,
+                "UseTracing": false,
+                "UseProxy": true
+            },
+            "UseServiceDiscovery": false,
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "localhost",
+                    "Port": 5200
+                }
+            ],
+            "UpstreamHost": null,
+            "DelegatingHandlers": [],
+            "Priority": 1,
+            "Timeout": 0,
+            "DangerousAcceptAnyServerCertificateValidator": false
+        }
+    ],
+    "Aggregates": [],
+    "GlobalConfiguration": {
+        "RequestIdKey": null,
+        "ServiceDiscoveryProvider": {
+            "Host": null,
+            "Port": 0,
+            "Type": null,
+            "Token": null,
+            "ConfigurationKey": null,
+            "PollingInterval": 0
+        },
+        "RateLimitOptions": {
+            "ClientIdHeader": "ClientId",
+            "QuotaExceededMessage": null,
+            "RateLimitCounterPrefix": "ocelot",
+            "DisableRateLimitHeaders": false,
+            "HttpStatusCode": 429
+        },
+        "QoSOptions": {
+            "ExceptionsAllowedBeforeBreaking": 0,
+            "DurationOfBreak": 0,
+            "TimeoutValue": 0
+        },
+        "BaseUrl": "http://localhost:10000",
+        "LoadBalancerOptions": {
+            "Type": null,
+            "Key": null,
+            "Expiry": 0
+        },
+        "DownstreamScheme": null,
+        "HttpHandlerOptions": {
+            "AllowAutoRedirect": false,
+            "UseCookieContainer": false,
+            "UseTracing": false,
+            "UseProxy": true
+        }
+    }
+}

--- a/src/CustomerManagementAPI/CustomerManagementAPI.csproj
+++ b/src/CustomerManagementAPI/CustomerManagementAPI.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.HealthChecks.SqlServer" Version="1.0.0" />
     <PackageReference Include="Pitstop.Infrastructure" Version="3.5.2" />

--- a/src/VehicleManagementAPI/VehicleManagementAPI.csproj
+++ b/src/VehicleManagementAPI/VehicleManagementAPI.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.HealthChecks.SqlServer" Version="1.0.0" />
     <PackageReference Include="Pitstop.Infrastructure" Version="3.5.2" />

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Pitstop.Infrastructure" Version="3.5.2" />
     <PackageReference Include="AutoMapper" Version="7.0.1" />
     <PackageReference Include="Polly" Version="6.1.0" />
-    <PackageReference Include="Refit" Version="4.6.16" />
+    <PackageReference Include="Refit" Version="4.6.30" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/WorkshopManagementAPI/WorkshopManagementAPI.csproj
+++ b/src/WorkshopManagementAPI/WorkshopManagementAPI.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.HealthChecks.SqlServer" Version="1.0.0" />

--- a/src/WorkshopManagementEventHandler/WorkshopManagementEventHandler.csproj
+++ b/src/WorkshopManagementEventHandler/WorkshopManagementEventHandler.csproj
@@ -8,11 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Pitstop.Infrastructure" Version="3.5.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Polly" Version="6.1.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
Building different demo where it required me to use a higher version of dotnet core.
So needed to update the packages.
During the upgrade of packages, found a breaking change in the api of ocelot.
Also using key instead of servicename because of https://github.com/ThreeMammals/Ocelot/issues/596
Using key should not break swagger, otherwise I would have removed the field.