### PR TITLE
Added ability to specify port for RabbitMQ

### DIFF
--- a/src/Infrastructure.Messaging/Configuration/Configuration.cs
+++ b/src/Infrastructure.Messaging/Configuration/Configuration.cs
@@ -14,19 +14,20 @@ namespace Pitstop.Infrastructure.Messaging.Configuration
         private static string _exchange;
         private static string _queue;
         private static string _routingKey;
+        private static string _port;
 
         public static void UseRabbitMQMessageHandler(this IServiceCollection services, IConfiguration config)
         {
             GetRabbitMQSettings(config, "RabbitMQHandler");
             services.AddTransient<IMessageHandler>(_ => new RabbitMQMessageHandler(
-                _host, _userName, _password, _exchange, _queue, _routingKey));
+                _host, _userName, _password, _exchange, _queue, _routingKey, _port));
         }
 
         public static void UseRabbitMQMessagePublisher(this IServiceCollection services, IConfiguration config)
         {
             GetRabbitMQSettings(config, "RabbitMQPublisher");
             services.AddTransient<IMessagePublisher>(_ => new RabbitMQMessagePublisher(
-                _host, _userName, _password, _exchange));
+                _host, _userName, _password, _exchange, _port));
         }        
 
         private static void GetRabbitMQSettings(IConfiguration config, string sectionName)
@@ -45,6 +46,16 @@ namespace Pitstop.Infrastructure.Messaging.Configuration
             {
                 valid = false;
                 errors.Add("Required config-setting 'Host' not found.");
+            }
+
+            _port = configSection["Port"];
+            if(!string.IsNullOrEmpty(_port))
+            {
+                if(!int.TryParse(_port, out int result))
+                {
+                    valid = false;
+                    errors.Add("Unable to parse config-setting 'Port' into an integer.");
+                }
             }
 
             _userName = configSection["UserName"];

--- a/src/Infrastructure.Messaging/RabbitMQMessagePublisher.cs
+++ b/src/Infrastructure.Messaging/RabbitMQMessagePublisher.cs
@@ -14,27 +14,32 @@ namespace Pitstop.Infrastructure.Messaging
     public sealed class RabbitMQMessagePublisher : IMessagePublisher, IDisposable
     {
         private readonly List<string> _hosts;
+        private readonly string _port = "5672";
         private readonly string _username;
         private readonly string _password;
         private readonly string _exchange;
         private IConnection _connection;
         private IModel _model;
 
-        public RabbitMQMessagePublisher(string host, string username, string password, string exchange)
-            : this(new List<string>() { host }, username, password, exchange)
+        public RabbitMQMessagePublisher(string host, string username, string password, string exchange, string port)
+            : this(new List<string>() { host }, username, password, exchange, port)
         {
         }
 
-        public RabbitMQMessagePublisher(IEnumerable<string> hosts, string username, string password, string exchange)
+        public RabbitMQMessagePublisher(IEnumerable<string> hosts, string username, string password, string exchange, string port)
         {
             _hosts = new List<string>(hosts);
             _username = username;
             _password = password;
             _exchange = exchange;
 
+            if (!string.IsNullOrEmpty(port))
+                _port = port;
+
             var logMessage = new StringBuilder();
             logMessage.AppendLine("Create RabbitMQ message-publisher instance using config:");
             logMessage.AppendLine($" - Hosts: {string.Join(',', _hosts.ToArray())}");
+            logMessage.AppendLine($" - Port: {_port}");
             logMessage.AppendLine($" - UserName: {_username}");
             logMessage.AppendLine($" - Password: {new string('*', _password.Length)}");
             logMessage.Append($" - Exchange: {_exchange}");
@@ -68,7 +73,8 @@ namespace Pitstop.Infrastructure.Messaging
                 .WaitAndRetry(9, r => TimeSpan.FromSeconds(5), (ex, ts) => { Log.Error("Error connecting to RabbitMQ. Retrying in 5 sec."); })
                 .Execute(() =>
                 {
-                    var factory = new ConnectionFactory() { UserName = _username, Password = _password };
+                    int port = int.Parse(_port);
+                    var factory = new ConnectionFactory() { UserName = _username, Password = _password, Port = port };
                     factory.AutomaticRecoveryEnabled = true;
                     _connection = factory.CreateConnection(_hosts);
                     _model = _connection.CreateModel();


### PR DESCRIPTION
I added the ability to specify the RabbitMQ port in the settings files.  This setting is not required and the default port is used when omitted from the settings files.  

I was wondering why you'd made the Infrastructure.Messaging a NuGet reference instead of a Project reference, I got my answer when attempting to do the Docker build as a project reference ;)

If this change is accepted, would I be able to trouble you to generate a new NuGet package?