### PR TITLE
Fix rabbitmq image version

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   rabbitmq:
-    image: rabbitmq:3-management-alpine
+    image: rabbitmq:3.8.19-management-alpine
     container_name: rabbitmq
     volumes:
       - rabbitmqdata:/var/lib/rabbitmq


### PR DESCRIPTION
With `3-management-alpine` one gets error about deprecated environment variables when run with docker-compose:

```
rabbitmq                          | error: RABBITMQ_DEFAULT_PASS is set but deprecated
rabbitmq                          | error: RABBITMQ_DEFAULT_USER is set but deprecated
rabbitmq                          | error: deprecated environment variables detected
rabbitmq                          | 
rabbitmq                          | Please use a configuration file instead; visit https://www.rabbitmq.com/configure.html to learn more
rabbitmq                          | 
rabbitmq exited with code 1
```
