### PR TITLE
Update ports of maildev/maildev containers

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -29,8 +29,8 @@ services:
     image: maildev/maildev
     container_name: mailserver
     ports:
-      - "25:25"
-      - "4000:80"
+      - "25:1025"
+      - "4000:1080"
 
   logserver:
     image: datalust/seq:latest

--- a/src/k8s/mailserver.yaml
+++ b/src/k8s/mailserver.yaml
@@ -42,10 +42,10 @@ spec:
   ports:
   - name: "smtp"
     port: 25
-    targetPort: 25
+    targetPort: 1025
   - name: "web"
     port: 4000
-    targetPort: 80
+    targetPort: 1080
     nodePort: 30002
   selector:
     app: mailserver


### PR DESCRIPTION
I noticed that maildev was not working correctly on my machine. After some investigation I noticed that maildev has changed its ports from 25 and 80 to 1025 and 1080. This is now also described in their [documentation](https://github.com/maildev/maildev/blob/master/docs/docker.md). Also, the Web UI states it now:

![image](https://user-images.githubusercontent.com/17497376/163549551-85232716-2f20-41d4-9ddd-0b0675db7a15.png)
