### PR TITLE
Remove critical vulnerability issue in WorkshopManagementEventHandler

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,12 +1,12 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />  
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />  
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
@@ -29,8 +29,8 @@
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageVersion Include="Serilog.Sinks.Seq" Version="5.2.2" />     
+    <PackageVersion Include="Serilog.Sinks.Seq" Version="5.2.2" />
     <PackageVersion Include="Pitstop.Infrastructure.Messaging" Version="3.0.3" />
+    <PackageVersion Include="System.Drawing.Common" Version="5.0.3" />
   </ItemGroup>
 </Project>
-

--- a/src/WorkshopManagementEventHandler/WorkshopManagementEventHandler.csproj
+++ b/src/WorkshopManagementEventHandler/WorkshopManagementEventHandler.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.Seq" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
 


### PR DESCRIPTION
In the project was used System.Drawing.Common 5.0.0. That version has a critical [security vulnerability](https://github.com/advisories/GHSA-rxg9-xrhp-64gj). 
In this PR I updated it from 5.0.0 to 5.0.3 and now there are no vulnerabilities in the WorkshopManagementEventHandler project.
When running `dotnet list package --vulnerable --include-transitive` it shows that there are now no vulnerabilities:
![fixed](https://github.com/EdwinVW/pitstop/assets/74299074/cbf1a5c2-8048-4ca6-97e3-a7a655f46708)
