### PR TITLE
Asdded async gulp task, so build in now not failing.

### DIFF
--- a/src/WebApp/gulpfile.js
+++ b/src/WebApp/gulpfile.js
@@ -20,14 +20,14 @@ var paths = {
     concatCssDest: webroot + "css/site.min.css"
 };
 
-gulp.task("min:js", function () {
+gulp.task("min:js", async function () {
     return gulp.src([paths.js, "!" + paths.minJs], { base: "." })
         .pipe(concat(paths.concatJsDest))
         .pipe(uglify())
         .pipe(gulp.dest("."));
 });
 
-gulp.task("min:css", function () {
+gulp.task("min:css", async function () {
     return gulp.src([paths.css, "!" + paths.minCss])
         .pipe(concat(paths.concatCssDest))
         .pipe(cssmin())


### PR DESCRIPTION
While spinning up from a recent fork, the solution failed to compile with an error of gulp task not finished. After making the gulp task async, the solution is running with no issues.