### PR TITLE
Resolved issue in start-all.sh script

### DIFF
--- a/src/k8s/scripts/start-all.sh
+++ b/src/k8s/scripts/start-all.sh
@@ -6,7 +6,7 @@
 
 MESHPOSTFIX=''
 
-if [ "$1" != "--nomesh" and  "$1" != "--istio" and "$1" != "--linkerd" ]
+if [ "$1" != "--nomesh" ] && [ "$1" != "--istio" ] && [ "$1" != "--linkerd" ]
 then
     echo "Error: You must specify how to start Pitstop:"
     echo "  start-all.ps1 < --nomesh | --istio | --linkerd >."


### PR DESCRIPTION
When I tried to run the `start-all.sh` script (Kubernetes) I got an error: `./start-all.sh: line 9: [: too many arguments`

I resolved this by replacing the `and` by `&&`. This is tested on Ubuntu (Linux).